### PR TITLE
Fix in file generate-api-server-config.js

### DIFF
--- a/tools/generate-api-server-config.js
+++ b/tools/generate-api-server-config.js
@@ -4,7 +4,7 @@ const { ConfigService } = require('../packages/bif-cmd-api-server/dist/lib/main/
 
 const main = async () => {
   const configService = new ConfigService();
-  const config = configService.generateExampleConfig();
+  const config = configService.newExampleConfig();
   const configJson = JSON.stringify(config, null, 4).concat('\n');
 
   if (fs.existsSync(config.configFile)) {


### PR DESCRIPTION
1. Fix the generate-api-server-config.js file so that it uses correct ConfigService function
2. Add steps for building in Readme.