### PR TITLE
docs(release): add script to bump openapi spec dep version

### DIFF
--- a/RELEASE_MANAGEMENT.md
+++ b/RELEASE_MANAGEMENT.md
@@ -31,6 +31,7 @@ git push --force-with-lease
 git checkout -b release-v1.1.3
 yarn run configure
 yarn lerna version 1.1.3 --ignore-scripts --conventional-commits --exact --git-remote upstream --message="chore(release): publish %s" --no-push --no-git-tag-version --no-ignore-changes --force-publish
+yarn tools:bump-openapi-spec-dep-versions
 ./tools/weaver-update-version.sh 1.1.3 .
 ./tools/go-gen-checksum.sh 1.1.3 .
 ```

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "npm-run-all": "4.1.5",
     "npm-watch": "0.11.0",
     "openapi-types": "12.1.3",
-    "prettier": "2.8.8",
+    "prettier": "3.0.3",
     "protoc-gen-ts": "0.8.6",
     "run-time-error": "1.4.0",
     "secp256k1": "4.0.3",

--- a/tools/bump-openapi-spec-dep-versions.ts
+++ b/tools/bump-openapi-spec-dep-versions.ts
@@ -208,7 +208,7 @@ async function bumpOpenApiSpecDepVersionsOneFile(
     throw new RuntimeError(`Could not locate .prettierrc.js in project dir`);
   }
   const prettierOpts = { ...prettierCfg, parser: "json" };
-  const prettyJson = prettier.format(specAsJsonString, prettierOpts);
+  const prettyJson = await prettier.format(specAsJsonString, prettierOpts);
 
   if (replacements.length > 0) {
     console.log(`${TAG} writing changes to disk or ${filePathRel}`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7830,7 +7830,7 @@ __metadata:
     npm-run-all: 4.1.5
     npm-watch: 0.11.0
     openapi-types: 12.1.3
-    prettier: 2.8.8
+    prettier: 3.0.3
     protoc-gen-ts: 0.8.6
     run-time-error: 1.4.0
     secp256k1: 4.0.3
@@ -36790,6 +36790,15 @@ __metadata:
   bin:
     prettier: bin-prettier.js
   checksum: b49e409431bf129dd89238d64299ba80717b57ff5a6d1c1a8b1a28b590d998a34e083fa13573bc732bb8d2305becb4c9a4407f8486c81fa7d55100eb08263cf8
+  languageName: node
+  linkType: hard
+
+"prettier@npm:3.0.3":
+  version: 3.0.3
+  resolution: "prettier@npm:3.0.3"
+  bin:
+    prettier: bin/prettier.cjs
+  checksum: e10b9af02b281f6c617362ebd2571b1d7fc9fb8a3bd17e371754428cda992e5e8d8b7a046e8f7d3e2da1dcd21aa001e2e3c797402ebb6111b5cd19609dd228e0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Commit to be reviewed

docs(release): add script to bump openapi spec dep version 

    Primary Changes
    ---------------
    1. Fixed tools/bump-openapi-spec-dep-versions.ts
    2. Update the docs to incorporate the same

    Secondary Changes         
    -----------------
    3. To incorporate 1), upgraded the prettier version

Fixes #479

[skip ci]